### PR TITLE
feat: display bits for zone picker

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,0 +1,1 @@
+pub mod zone_picker;

--- a/src/components/zone_picker.rs
+++ b/src/components/zone_picker.rs
@@ -1,0 +1,51 @@
+use crate::db::Zone;
+use std::rc::Rc;
+use yew::prelude::*;
+
+#[derive(PartialEq, Properties)]
+pub struct Props {
+    pub active_zone: Option<usize>,
+    pub zones: Rc<Vec<Zone>>,
+}
+
+#[function_component]
+pub fn ZonePicker(props: &Props) -> Html {
+    // FIXME: original has a "none" item in the list to restore the collectibles to being unfiltered
+    let items = props
+        .zones
+        .iter()
+        .copied()
+        .map(|zone| {
+            html! {
+                <li ~key={zone.id}>
+                <Item active_zone={props.active_zone} item={zone}/>
+                </li>
+            }
+        })
+        .collect::<Html>();
+
+    html! {
+        <ul>{items}</ul>
+    }
+}
+
+#[derive(PartialEq, Properties)]
+pub struct ItemProps {
+    active_zone: Option<usize>,
+    item: Zone,
+}
+
+#[function_component]
+pub fn Item(props: &ItemProps) -> Html {
+    let active = if Some(props.item.id) == props.active_zone {
+        "active"
+    } else {
+        ""
+    };
+
+    html! {
+        <div class={classes!("mk", "item", active)}>
+            {props.item.name}
+        </div>
+    }
+}

--- a/src/db/categories.rs
+++ b/src/db/categories.rs
@@ -1,3 +1,4 @@
+#[derive(Copy, Clone, PartialEq)]
 pub struct Category {
     pub id: usize,
     pub name: &'static str,

--- a/src/db/collectibles.rs
+++ b/src/db/collectibles.rs
@@ -1,4 +1,4 @@
-// id, short_name, name, description, category, collected
+#[derive(Copy, Clone, PartialEq)]
 pub struct Collectible {
     pub id: usize,
     pub short_name: Option<&'static str>,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,7 +1,7 @@
-use crate::db::categories::Category;
-use crate::db::zones::Zone;
+pub use crate::db::categories::Category;
+pub use crate::db::zones::Zone;
 use collectible_zone_membership::CollectibleZoneMembership;
-use collectibles::Collectible;
+pub use collectibles::Collectible;
 
 mod categories;
 mod collectible_zone_membership;
@@ -44,13 +44,9 @@ impl<'a> Database<'a> {
         &self,
         category_id: usize,
     ) -> impl Iterator<Item = &Collectible> {
-        self.collectibles.iter().filter_map(move |x| {
-            if x.category_id != category_id {
-                None
-            } else {
-                Some(x)
-            }
-        })
+        self.collectibles
+            .iter()
+            .filter(move |x| x.category_id != category_id)
     }
 
     pub fn collectible_by_id(&self, id: usize) -> &Collectible {

--- a/src/db/zones.rs
+++ b/src/db/zones.rs
@@ -1,3 +1,4 @@
+#[derive(Copy, Clone, PartialEq)]
 pub struct Zone {
     pub id: usize,
     pub name: &'static str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,16 @@
+use components::zone_picker::ZonePicker;
 use yew::prelude::*;
-
+mod components;
 mod db;
 
 #[function_component]
 fn App() -> Html {
-    let counter = use_state(|| 0);
-    let onclick = {
-        let counter = counter.clone();
-        move |_| {
-            let value = *counter + 1;
-            counter.set(value);
-        }
-    };
-
+    let zones = use_memo((), |_| {
+        let data = db::Database::default();
+        data.zones().copied().collect::<Vec<_>>()
+    });
     html! {
-        <div>
-            <button {onclick}>{ "+1" }</button>
-            <p>{ *counter }</p>
-        </div>
+        <ZonePicker zones={zones} active_zone={None}/>
     }
 }
 


### PR DESCRIPTION
This diff just gets the zones rendering as an unordered list in plain html.

There's a bit of a shortfall here, aside from the styling. There's no state management so selecting a zone is not yet possible.

There's also a fixme related to the "All" or "Unfiltered" state which was previously represented at the top of the list via an "empty" list item.

I'm not sure how I want to handle this use case in the Yew version, but I'll revisit this after I get some state management going.