### PR TITLE
feat: collectible list

### DIFF
--- a/src/components/collectible_list.rs
+++ b/src/components/collectible_list.rs
@@ -1,0 +1,118 @@
+use crate::db::Collectible;
+use crate::store::{Action, StoreContext};
+use std::collections::BTreeSet;
+use std::rc::Rc;
+use yew::prelude::*;
+
+#[function_component]
+pub fn CollectibleList() -> Html {
+    let store = use_context::<StoreContext>().expect("Store ctx");
+    let active_items = use_memo(store.active_zone, |active_zone| match active_zone {
+        None => crate::DATABASE
+            .collectibles()
+            .map(|x| x.id)
+            .collect::<BTreeSet<_>>(),
+        Some(active_zone) => crate::DATABASE
+            .collectibles_by_zone(*active_zone)
+            .map(|x| x.id)
+            .collect::<BTreeSet<_>>(),
+    });
+
+    let groups = crate::DATABASE
+        .categories()
+        .map(|cat| {
+            let items = crate::DATABASE
+                .collectibles_by_category(cat.id)
+                .copied()
+                .collect::<Vec<_>>();
+            html! {
+                <CollectibleGroup
+                    key={cat.name}
+                    active_items={active_items.clone()}
+                    label={cat.name}
+                    {items}/>
+            }
+        })
+        .collect::<Html>();
+
+    html! {
+        <div class="collectibles">{groups}</div>
+    }
+}
+
+#[derive(PartialEq, Properties)]
+pub struct CollectibleGroupProps {
+    active_items: Rc<BTreeSet<usize>>,
+    label: &'static str,
+    items: Vec<Collectible>,
+}
+
+#[function_component]
+pub fn CollectibleGroup(props: &CollectibleGroupProps) -> Html {
+    let store = use_context::<StoreContext>().expect("Store ctx");
+
+    // FIXME: memo?
+    let collected_in_group: BTreeSet<usize> = {
+        let item_ids = props
+            .items
+            .iter()
+            .map(|x| x.id)
+            .collect::<BTreeSet<usize>>();
+
+        &store.collected & &item_ids
+    };
+
+    let collected_count = collected_in_group.len();
+    let total_count = props.items.len();
+    let counts = format!("({collected_count}/{total_count})");
+    // FIXME: sort by (short name, name) if needed
+    let items = props
+        .items
+        .iter()
+        .map(|x| {
+            let active = props.active_items.contains(&x.id);
+            html! {
+                <li key={x.id}>
+                    <CollectibleItem {active} item={*x}/>
+                </li>
+            }
+        })
+        .collect::<Html>();
+
+    html! {
+        <div class="collectible-group">
+            <h4 class="heading">{props.label}{" "}{counts}</h4>
+            <ul>{items}</ul>
+        </div>
+    }
+}
+
+#[derive(PartialEq, Properties)]
+pub struct CollectibleItemProps {
+    active: bool,
+    item: Collectible,
+}
+
+#[function_component]
+pub fn CollectibleItem(props: &CollectibleItemProps) -> Html {
+    let store = use_context::<StoreContext>().expect("Store ctx");
+
+    let id = props.item.id;
+    let collected = store.collected.contains(&id);
+    let onchange = Callback::from(move |e: Event| {
+        e.prevent_default();
+        e.stop_propagation();
+        store.dispatch(Action::ToggleCollectible(id));
+    });
+
+    html! {
+        <div class={classes!("mk", "item", if !props.active {"inactive"} else {""})}>
+            <label>
+                <input type="checkbox" checked={collected} {onchange}/>
+                {props.item.name}
+                {" "}
+                <span>{props.item.short_name}</span>
+            </label>
+        </div>
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,1 +1,2 @@
+pub mod collectible_list;
 pub mod zone_picker;

--- a/src/components/zone_picker.rs
+++ b/src/components/zone_picker.rs
@@ -1,4 +1,3 @@
-use crate::db::Zone;
 use crate::store::{Action, StoreContext};
 use yew::prelude::*;
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -41,7 +41,7 @@ impl<'a> Database<'a> {
     ) -> impl Iterator<Item = &Collectible> {
         self.collectibles
             .iter()
-            .filter(move |x| x.category_id != category_id)
+            .filter(move |x| x.category_id == category_id)
     }
 
     pub fn collectible_by_id(&self, id: usize) -> &Collectible {
@@ -52,10 +52,10 @@ impl<'a> Database<'a> {
 
     pub fn collectibles_by_zone(&self, zone_id: usize) -> impl Iterator<Item = &Collectible> {
         self.membership.iter().filter_map(move |x| {
-            if x.zone_id != zone_id {
-                None
-            } else {
+            if x.zone_id == zone_id {
                 Some(self.collectible_by_id(x.collectible_id))
+            } else {
+                None
             }
         })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use crate::store::StoreContext;
+use components::collectible_list::CollectibleList;
 use components::zone_picker::ZonePicker;
 use store::Store;
 use yew::prelude::*;
@@ -15,6 +16,7 @@ fn App() -> Html {
 
     html! {
         <ContextProvider<StoreContext> context={store.clone()}>
+            <CollectibleList/>
             <ZonePicker active_zone={store.active_zone}/>
         </ContextProvider<StoreContext>>
     }


### PR DESCRIPTION
Build out the state management and DOM eventing needed to toggle the checklist items, both in the document and in the store.

When (later) local storage is brought into the mix, we'll do a read at the top of the component tree to populate the initial state of the `Store`, then also update the storage via the reducer when it handles `ToggleCollectible` actions.