### PR TITLE
feat: rough tabbed UI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,14 +10,46 @@ mod store;
 
 const DATABASE: db::Database = db::Database::new();
 
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+enum Tab {
+    #[default]
+    Collectibles,
+    Zones,
+}
+
 #[function_component]
 fn App() -> Html {
     let store = use_reducer(Store::default);
+    let active_tab = use_state_eq(Tab::default);
+
+    let tabs = html! {
+      <ul>
+        <li class={classes!(if *active_tab == Tab::Collectibles {"active"} else {""})}
+            onclick={
+                Callback::from({
+                let active_tab = active_tab.clone();
+                move |_| active_tab.set(Tab::Collectibles)})
+            }
+            >{"items"}</li>
+        <li class={classes!(if *active_tab == Tab::Zones {"active"} else {""})}
+            onclick={
+                Callback::from({
+                let active_tab = active_tab.clone();
+                move |_| active_tab.set(Tab::Zones)})
+            }>{"zones"}</li>
+      </ul>
+    };
+
+    let content = if *active_tab == Tab::Collectibles {
+        html! { <CollectibleList/> }
+    } else {
+        html! { <ZonePicker active_zone={store.active_zone}/> }
+    };
 
     html! {
         <ContextProvider<StoreContext> context={store.clone()}>
-            <CollectibleList/>
-            <ZonePicker active_zone={store.active_zone}/>
+        {tabs}
+        {content}
         </ContextProvider<StoreContext>>
     }
 }


### PR DESCRIPTION
It doesn't look like much, but this diff adds a couple of list items to the top of the page. Clicking on them will control the visibility of the collectible list and zone picker.

This is a tabbed UI in essence.

In the original React version, this was presented as a pair of icons with a change in background color to indicate which was active. Something similar should be possible once styling is underway.

Further refactors to tidy up are desirable, but for now this will do.