### PR TITLE
chore: add tailwind

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8"/>
     <title>Markhor</title>
+    <link data-trunk rel="tailwind-css" href="./input.css"/>
 </head>
 <body></body>
 </html>

--- a/input.css
+++ b/input.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./src/**/*.rs"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+


### PR DESCRIPTION
Using the tailwindcss cli: `tailwindcss init` to produce a default config.

Added bare-bones input.css to bring in the tailwind stuff, a glob to search for class names under the rust source tree (where
our components are defined) in the config, and a `<link/>` in the index.html so trunk can handle the style compilation.

Not yet sure if more configuration is needed to perform pruning of the stylesheet etc.