### PR TITLE
feat: use scss for styling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Owen Nelson <onelson@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-gloo = "0.10.0"
+gloo = "0.11.0"
 wasm-bindgen = "0.2.88"
+web-sys = { version = "0.3.66", features = ["HtmlSelectElement"] }
 yew = { version = "0.21", features = ["csr"] }
 

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8"/>
     <title>Markhor</title>
+    <link data-trunk rel="scss" href="./input.scss"/>
 </head>
 <body></body>
 </html>

--- a/input.scss
+++ b/input.scss
@@ -1,0 +1,94 @@
+/* latin-ext */
+@font-face {
+  font-family: 'Doppio One';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Doppio One Regular'), local('DoppioOne-Regular'), url(https://fonts.gstatic.com/s/doppioone/v4/vX75dKv8e7RM59WCf4mUTiEAvth_LlrfE80CYdSH47w.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Doppio One';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Doppio One Regular'), local('DoppioOne-Regular'), url(https://fonts.gstatic.com/s/doppioone/v4/DGr_HuCg-_zePcleoqvEX_k_vArhqVIZ0nv9q090hN8.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215;
+}
+
+
+$textColor: #2b2a1e;
+$panelBg: #0e0f0a;
+$itemBg: #727561;
+$activeItemBg: #b6b6a0;
+$highlightItemBg: lighten($itemBg, 10%);
+
+body {
+  font-family: 'Doppio One', sans-serif;
+  text-transform: uppercase;
+  color: $textColor;
+  background: $panelBg;
+}
+
+.menu {
+  background: $panelBg;
+  .icon.item {
+    background-color: $itemBg;
+    &.active {
+      background-color: $activeItemBg;
+    }
+    &:hover {
+      background-color: $highlightItemBg;
+    }
+  }
+
+  margin: 0;
+  padding: 0;
+  border-bottom: none;
+}
+
+
+.collectible-group {
+  background: $panelBg;
+  border: 2px $activeItemBg solid;
+  margin-bottom: 1em;
+
+  .heading {
+    background: $activeItemBg;
+    margin: 0 auto;
+    padding: 0.25em 0.3em;
+  }
+}
+
+.list {
+  padding: 0.25em;
+  margin: 0;
+  list-style: none;
+
+  .mk.item {
+    display: block;
+    background-color: $itemBg;
+    &:hover {
+      background: $highlightItemBg;
+    }
+    &.active {
+      background: $activeItemBg;
+    }
+    &.inactive {
+      opacity: 0.5;
+    }
+    label {
+      cursor: pointer;
+      display: block;
+      padding: 0.25em 0.1em;
+    }
+  }
+}
+
+
+.total-count {
+  position: absolute;
+  right: 0;
+  top: 3px;
+  background: $activeItemBg;
+  padding: 0.5em;
+}

--- a/src/components/collectible_list.rs
+++ b/src/components/collectible_list.rs
@@ -82,7 +82,9 @@ pub fn CollectibleGroup(props: &CollectibleGroupProps) -> Html {
     html! {
         <div class="collectible-group">
             <h4 class="heading">{props.label}{" "}{counts}</h4>
-            <ul>{items}</ul>
+            <ul class="list">
+                {items}
+            </ul>
         </div>
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,46 +10,19 @@ mod store;
 
 const DATABASE: db::Database = db::Database::new();
 
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
-enum Tab {
-    #[default]
-    Collectibles,
-    Zones,
-}
-
 #[function_component]
 fn App() -> Html {
     let store = use_reducer(Store::default);
-    let active_tab = use_state_eq(Tab::default);
 
-    let tabs = html! {
-      <ul>
-        <li class={classes!(if *active_tab == Tab::Collectibles {"active"} else {""})}
-            onclick={
-                Callback::from({
-                let active_tab = active_tab.clone();
-                move |_| active_tab.set(Tab::Collectibles)})
-            }
-            >{"items"}</li>
-        <li class={classes!(if *active_tab == Tab::Zones {"active"} else {""})}
-            onclick={
-                Callback::from({
-                let active_tab = active_tab.clone();
-                move |_| active_tab.set(Tab::Zones)})
-            }>{"zones"}</li>
-      </ul>
-    };
-
-    let content = if *active_tab == Tab::Collectibles {
-        html! { <CollectibleList/> }
-    } else {
-        html! { <ZonePicker active_zone={store.active_zone}/> }
-    };
+    let collected_count = store.collected.len();
+    let total_count = use_memo((), |_| DATABASE.collectibles().count());
+    let counts = format!("({collected_count}/{total_count})");
 
     html! {
         <ContextProvider<StoreContext> context={store.clone()}>
-        {tabs}
-        {content}
+            <ZonePicker active_zone={store.active_zone}/>
+            <div class="total-count">{counts}</div>
+            <CollectibleList/>
         </ContextProvider<StoreContext>>
     }
 }


### PR DESCRIPTION
Instead of trying to rebuild with tailwind, ths approach converts some of the original less styles into scss (which is supported by the bundler).

Since semantic-ui is not being used, there are some gaps/tweaks needed to get us a finished design, but it looks like tailwind wouldn't help much in this regard anyway.