### PR TITLE
chore: style fixups

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"/>
     <title>Markhor</title>
-    <link data-trunk rel="scss" href="./input.scss"/>
+    <link data-trunk rel="scss" href="./styles/main.scss"/>
 </head>
 <body>
     <script data-goatcounter="https://markhor.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>

--- a/input.scss
+++ b/input.scss
@@ -32,6 +32,7 @@ body {
 
 .topbar {
   position: fixed;
+  z-index: 10;
   display: flex;
   flex-wrap: nowrap;
   justify-content: space-between;

--- a/styles/_reset.css
+++ b/styles/_reset.css
@@ -1,0 +1,48 @@
+/* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -1,3 +1,5 @@
+@import 'reset';
+
 /* latin-ext */
 @font-face {
   font-family: 'Doppio One';


### PR DESCRIPTION
A few style fixes.

- sets z-index on topbar to avoid list items with opacity directives rendering on top.
- include a CSS reset to try and make mobile browsers look more consistent.