### PR TITLE
fix: raise font-size for topbar

### DIFF
--- a/styles/main.scss
+++ b/styles/main.scss
@@ -33,6 +33,8 @@ body {
 }
 
 .topbar {
+  font-size: 1.2rem;
+
   position: fixed;
   z-index: 10;
   display: flex;
@@ -58,7 +60,7 @@ body {
 }
 
 .collectibles {
-  padding-top: 3rem;
+  padding-top: 3.25rem;
 }
 .collectible-group {
   background: $panelBg;


### PR DESCRIPTION
The topbar is still rendering tiny on firefox mobile. Trying to set it a little larger explictly.